### PR TITLE
Hash chunk names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desmos/esbuild-worker-dedupe",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/desmosinc/esbuild-worker-dedupe"

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export const inlineDedupedWorker: typeof public_types.inlineDedupedWorker =
         build.initialOptions.outdir = outdir;
         build.initialOptions.splitting = true;
         build.initialOptions.format = "esm";
-        build.initialOptions.chunkNames = "__shared_chunk";
+        build.initialOptions.chunkNames = "__shared_chunk-[hash]";
         // If there's an outfile option, remove it, because we need to build with an outdir
         // to get multiple chunks first. We'll use outfile when we combine them at the end.
         delete build.initialOptions.outfile;


### PR DESCRIPTION
This PR hashes generated chunks. Without hashes in the chunk names, errors are thrown when the content of the output files is different.

> `✘ [ERROR] Two output files share the same path but have different contents: ../server/__shared_chunk.js`