### PR TITLE
Add deprecation warning to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Deprecated
+
+This repo is no longer being maintained.
+
+---
+
 Proof of concept for inlining web worker code with esbuild with shared dependencies deduplicated.
 
 ## Try it


### PR DESCRIPTION
Adds a deprecation warning to the repo (not referencing knox, since this is a public repo). Will also mark the repo as archived after merging this.

Not clear if there's anything we should do on npm?